### PR TITLE
Fix #issue-3726513496 by shading the ConnectorAPI into node.

### DIFF
--- a/node/build.gradle.kts
+++ b/node/build.gradle.kts
@@ -13,6 +13,7 @@ repositories {
 dependencies {
     implementation(project(":core"))
     implementation(project(":api"))
+    implementation(project(":connector"))
 
     implementation(libs.simpleyaml) {
         exclude(group = "org.yaml", module = "snakeyaml")


### PR DESCRIPTION
This fixes the problem I had, when sending players to another service via the API's Service.connectWithService method, which triggers the ConnectPlayerWithServiceEvent and makes the node handle it, which cannot happen due to the node not having the ConnectionAPI shaded, which causes the class to be missing.